### PR TITLE
Added ICC mechanism and template

### DIFF
--- a/gvpn/BaseTopologyManager.py
+++ b/gvpn/BaseTopologyManager.py
@@ -90,6 +90,10 @@ class BaseTopologyManager(ControllerModule):
                 self.CBTMappings[cbt.uid] = [idle_peer_CBT.uid]
                 self.pendingCBT[cbt.uid] = cbt
 
+            elif(cbt.action == "ICC_MSG"):
+                msg = cbt.data
+                msg_type = msg.get("msg_type", None)
+
             elif(cbt.action == "LINK_TRIMMER"):
                 stateCBT = self.CFxHandle.createCBT(initiator='Base'
                                                     'TopologyManager',

--- a/gvpn/TincanDispatcher.py
+++ b/gvpn/TincanDispatcher.py
@@ -124,11 +124,10 @@ class TincanDispatcher(ControllerModule):
 
                 # Send the Tincan Packet to BaseTopologyManager
 
-                packet = data[2:]
                 CBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
                                                recipient='BaseTopologyManager',
                                                action='TINCAN_PACKET',
-                                               data=packet)
+                                               data=data[2:])
                 self.CFxHandle.submitCBT(CBT)
 
             else:

--- a/gvpn/TincanDispatcher.py
+++ b/gvpn/TincanDispatcher.py
@@ -48,103 +48,117 @@ class TincanDispatcher(ControllerModule):
             self.CFxHandle.submitCBT(logCBT)
             sys.exit()
 
-        if data[1] == self.tincan_control:
+        if "TINCAN_PKT" == cbt.action:
 
-            msg = json.loads(data[2:])
-            logCBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                              recipient='Logger',
-                                              action='debug',
-                                              data="recv {0} {1}"
-                                              .format(addr, data[2:]))
-            self.CFxHandle.submitCBT(logCBT)
-            msg_type = msg.get("type", None)
+            if data[1] == self.tincan_control:
 
-            if msg_type == "echo_request":
+                msg = json.loads(data[2:])
+                logCBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
+                                                  recipient='Logger',
+                                                  action='debug',
+                                                  data="recv {0} {1}"
+                                                  .format(addr, data[2:]))
+                self.CFxHandle.submitCBT(logCBT)
+                msg_type = msg.get("type", None)
 
-                # Reply to the echo_request
+                if msg_type == "echo_request":
 
-                echo_data = {
-                   'm_type': tincan_control,
-                   'dest_addr': addr[0],
-                   'dest_port': addr[1]
-                }
+                    # Reply to the echo_request
 
-                echoCBT = self.CFxHandle.createCBT(initiator='Tincan'
-                                                   'Dispatcher',
-                                                   recipient='TincanSender',
-                                                   action='ECHO_REPLY',
-                                                   data=echo_data)
-                self.CFxHandle.submitCBT(echoCBT)
+                    echo_data = {
+                       'm_type': tincan_control,
+                       'dest_addr': addr[0],
+                       'dest_port': addr[1]
+                    }
 
-            elif msg_type == "local_state":
+                    echoCBT = self.CFxHandle.createCBT(initiator='Tincan'
+                                                       'Dispatcher',
+                                                       recipient='TincanSender',
+                                                       action='ECHO_REPLY',
+                                                       data=echo_data)
+                    self.CFxHandle.submitCBT(echoCBT)
 
-                # Send CBT to Watchdog to store ipop_state
+                elif msg_type == "local_state":
 
-                CBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                               recipient='Watchdog',
-                                               action='STORE_IPOP_STATE',
-                                               data=msg)
-                self.CFxHandle.submitCBT(CBT)
+                    # Send CBT to Watchdog to store ipop_state
 
-            elif msg_type == "peer_state":
+                    CBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
+                                                   recipient='Watchdog',
+                                                   action='STORE_IPOP_STATE',
+                                                   data=msg)
+                    self.CFxHandle.submitCBT(CBT)
 
-                # Send CBT to Monitor to store peer state
+                elif msg_type == "peer_state":
 
-                CBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                               recipient='Monitor',
-                                               action='STORE_PEER_STATE',
-                                               data=msg)
-                self.CFxHandle.submitCBT(CBT)
+                    # Send CBT to Monitor to store peer state
 
-            elif (msg_type == "con_stat" or msg_type == "con_req" or
-                  msg_type == "con_resp" or msg_type == "send_msg"):
+                    CBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
+                                                   recipient='Monitor',
+                                                   action='STORE_PEER_STATE',
+                                                   data=msg)
+                    self.CFxHandle.submitCBT(CBT)
 
+                elif (msg_type == "con_stat" or msg_type == "con_req" or
+                      msg_type == "con_resp" or msg_type == "send_msg"):
+
+                    CBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
+                                                   recipient='BaseTopologyManager',
+                                                   action='TINCAN_MSG',
+                                                   data=msg)
+                    self.CFxHandle.submitCBT(CBT)
+
+            #  If a packet that is destined to yet no p2p connection
+            #  established node, the packet as a whole is forwarded to
+            #  controller
+            # |-------------------------------------------------------------|
+            # | offset(byte) |                                              |
+            # |-------------------------------------------------------------|
+            # |      0       | ipop version                                 |
+            # |      1       | message type                                 |
+            # |      2       | source uid                                   |
+            # |     22       | destination uid                              |
+            # |     42       | Payload (Ethernet frame)                     |
+            # |-------------------------------------------------------------|
+
+            elif data[1] == self.tincan_packet:
+
+                # Send the Tincan Packet to BaseTopologyManager
+
+                packet = data[2:]
                 CBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
                                                recipient='BaseTopologyManager',
-                                               action='TINCAN_MSG',
-                                               data=msg)
+                                               action='TINCAN_PACKET',
+                                               data=packet)
                 self.CFxHandle.submitCBT(CBT)
 
-        #  If a packet that is destined to yet no p2p connection
-        #  established node, the packet as a whole is forwarded to
-        #  controller
-        # |-------------------------------------------------------------|
-        # | offset(byte) |                                              |
-        # |-------------------------------------------------------------|
-        # |      0       | ipop version                                 |
-        # |      1       | message type                                 |
-        # |      2       | source uid                                   |
-        # |     22       | destination uid                              |
-        # |     42       | Payload (Ethernet frame)                     |
-        # |-------------------------------------------------------------|
+            else:
 
-        elif data[1] == self.tincan_packet:
+                logCBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
+                                                  recipient='Logger',
+                                                  action='error',
+                                                  data="Tincan: "
+                                                  "Unrecognized message "
+                                                  "received from Tincan")
+                self.CFxHandle.submitCBT(logCBT)
 
-            # Send the Tincan Packet to BaseTopologyManager
+                logCBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
+                                                  recipient='Logger',
+                                                  action='debug',
+                                                  data="{0}".format(data[0:].
+                                                                    encode("hex")))
+                self.CFxHandle.submitCBT(logCBT)
+                sys.exit()
 
-            CBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                           recipient='BaseTopologyManager',
-                                           action='TINCAN_PACKET',
-                                           data=data)
-            self.CFxHandle.submitCBT(CBT)
+        elif "ICC_PKT" == cbt.action:
 
-        else:
+            if data[1] == self.tincan_control:
 
-            logCBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                              recipient='Logger',
-                                              action='error',
-                                              data="Tincan: "
-                                              "Unrecognized message "
-                                              "received from Tincan")
-            self.CFxHandle.submitCBT(logCBT)
-
-            logCBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                              recipient='Logger',
-                                              action='debug',
-                                              data="{0}".format(data[0:].
-                                                                encode("hex")))
-            self.CFxHandle.submitCBT(logCBT)
-            sys.exit()
+                msg = json.loads(data[2:])
+                CBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
+                                               recipient='BaseTopologyManager',
+                                               action='ICC_MSG',
+                                               data=msg)
+                self.CFxHandle.submitCBT(CBT)
 
     def timer_method(self):
         pass

--- a/gvpn/TincanListener.py
+++ b/gvpn/TincanListener.py
@@ -9,10 +9,12 @@ class TincanListener(ControllerModule):
 
         super(TincanListener, self).__init__()
         self.CFxHandle = CFxHandle
+        self.CMConfig = paramDict
         self.sock = sock_list[0]
         self.sock_svr = sock_list[1]
+        if self.CMConfig['icc']:
+            self.sock_icc = sock_list[2]
         self.sock_list = sock_list
-        self.CMConfig = paramDict
 
     def initialize(self):
 
@@ -41,13 +43,21 @@ class TincanListener(ControllerModule):
 
             for sock in socks:
                 if(sock == self.sock or sock == self.sock_svr):
-                    sock_to_read = socks[0]
-                    data, adr = sock_to_read.recvfrom(self.CMConfig["buf_size"])
+                    data,addr = sock.recvfrom(self.CMConfig["buf_size"])
                     cbt = self.CFxHandle.createCBT(initiator='TincanListener',
                                                    recipient='Tincan'
                                                    'Dispatcher',
                                                    action='TINCAN_PKT',
-                                                   data=[data, adr])
+                                                   data=[data, addr])
+                    self.CFxHandle.submitCBT(cbt)
+
+                elif(sock == self.sock_icc):
+                    data,addr = sock.recvfrom(self.CMConfig["buf_size"])
+                    cbt = self.CFxHandle.createCBT(initiator='TincanListener',
+                                                   recipient='Tincan'
+                                                   'Dispatcher',
+                                                   action='ICC_PKT',
+                                                   data=[data, addr])
                     self.CFxHandle.submitCBT(cbt)
 
     def terminate(self):

--- a/gvpn/TincanSender.py
+++ b/gvpn/TincanSender.py
@@ -1,6 +1,7 @@
 import json
 import socket
 import random
+import ipoplib
 from ControllerModule import ControllerModule
 
 

--- a/gvpn/TincanSender.py
+++ b/gvpn/TincanSender.py
@@ -17,6 +17,8 @@ class TincanSender(ControllerModule):
         self.CMConfig = paramDict
         self.sock = sock_list[0]
         self.sock_svr = sock_list[1]
+        if self.CMConfig['icc']:
+            self.sock_icc = sock_list[2]
 
     def initialize(self):
 
@@ -68,6 +70,16 @@ class TincanSender(ControllerModule):
             self.make_remote_call(self.sock_svr, m_type=m_type,
                                   dest_addr=dest_addr, dest_port=dest_port,
                                   payload=None, type="echo_reply")
+
+        elif(cbt.action == 'DO_SEND_ICC_MSG'):
+            msg = json.dumps(cbt.data.get('msg'))
+            dest_addr = self.gen_ip6(cbt.data.get('dest_uid'))
+            dest_port = self.CMConfig["icc_port"]
+            self.sock_icc.sendto(self.ipop_ver + self.tincan_control + msg,
+                                 (dest_addr, dest_port))
+
+        elif(cbt.action == 'DO_INSERT_DATA_PACKET'):
+            ipoplib.send_packet(self.sock, cbt.data.decode("hex"))
 
         else:
             logCBT = self.CFxHandle.createCBT(initiator='TincanSender',

--- a/gvpn/Watchdog.py
+++ b/gvpn/Watchdog.py
@@ -38,7 +38,7 @@ class Watchdog(ControllerModule):
 
         else:
 
-            logCBT = self.CFxHandle.createCBT(initiator='Monitor',
+            logCBT = self.CFxHandle.createCBT(initiator='Watchdog',
                                               recipient='Logger',
                                               action='error',
                                               data="Watchdog: Unrecognized CBT"

--- a/gvpn/config.json
+++ b/gvpn/config.json
@@ -6,6 +6,8 @@
         "xmpp_host": "",
         "stat_report": true,
         "tincan_logging": 0,
+        "icc": true,
+        "icc_port": 30000,
         "vpn_type": "GroupVPN"
     },
     "TincanListener" : {


### PR DESCRIPTION
Summary of modifications:
config.json - Add field for ICC and ICC port
CFx - Create ICC socket and append to socket list, if ICC is enabled; Pass ICC and ICC port config fields into TincanListener and TincanSender
TincanListener: Listen to ICC socket, if ICC is enabled; Send ICC messages to TincanDispatcher
TincanDispatcher: Multiplex ICC messages (currently dispatched to BaseTopologyManager)
BaseTopologyManager: Template for interpreting ICC messages
TincanSender: Added "DO_SEND_ICC_MSG" for sending an ICC message; Added "DO_INSERT_DATA_PACKET" for inserting data (tincan) packets into IPOP tap device.

Additional notes:
The ICC mechanism was tested in a virtualized environment
The names "DO_SEND_ICC_MSG" and "DO_INSERT_DATA_PACKET" are currently not IPOP API calls; there are some things to discuss, but for now, it might be okay.
